### PR TITLE
Field single line refactor

### DIFF
--- a/Example/TLFormView.xcodeproj/project.pbxproj
+++ b/Example/TLFormView.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		9B5B54FF1AC4F0D900604DE2 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B5B54FE1AC4F0D900604DE2 /* MobileCoreServices.framework */; };
+		9BE9B0EE1B02562E009DA0BD /* TLFormFieldDateTime.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0ED1B02562E009DA0BD /* TLFormFieldDateTime.m */; };
+		9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */; };
+		9BE9B0F51B03BD13009DA0BD /* NSNumber+NumberType.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */; };
 		9BECE1881A9B5B4D00CE2FD5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE1871A9B5B4D00CE2FD5 /* main.m */; };
 		9BECE18B1A9B5B4D00CE2FD5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18A1A9B5B4D00CE2FD5 /* AppDelegate.m */; };
 		9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18D1A9B5B4D00CE2FD5 /* ViewController.m */; };
@@ -27,6 +30,12 @@
 
 /* Begin PBXFileReference section */
 		9B5B54FE1AC4F0D900604DE2 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		9BE9B0EC1B02562E009DA0BD /* TLFormFieldDateTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TLFormFieldDateTime.h; sourceTree = "<group>"; };
+		9BE9B0ED1B02562E009DA0BD /* TLFormFieldDateTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldDateTime.m; sourceTree = "<group>"; };
+		9BE9B0EF1B03A81B009DA0BD /* TLFormFieldNumeric.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TLFormFieldNumeric.h; sourceTree = "<group>"; };
+		9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldNumeric.m; sourceTree = "<group>"; };
+		9BE9B0F31B03BD13009DA0BD /* NSNumber+NumberType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+NumberType.h"; sourceTree = "<group>"; };
+		9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+NumberType.m"; sourceTree = "<group>"; };
 		9BECE1821A9B5B4D00CE2FD5 /* TLFormView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TLFormView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BECE1861A9B5B4D00CE2FD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BECE1871A9B5B4D00CE2FD5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -71,6 +80,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9BE9B0F21B03BCF3009DA0BD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9BE9B0F31B03BD13009DA0BD /* NSNumber+NumberType.h */,
+				9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		9BECE1791A9B5B4D00CE2FD5 = {
 			isa = PBXGroup;
 			children = (
@@ -116,6 +134,7 @@
 		9BECE1AB1A9B5B9800CE2FD5 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				9BE9B0F21B03BCF3009DA0BD /* Extensions */,
 				9BECE1CF1A9F898900CE2FD5 /* Style */,
 				9BECE1B11A9CACEA00CE2FD5 /* Fields */,
 				9BECE1AD1A9B5B9800CE2FD5 /* TLFormView.h */,
@@ -144,6 +163,10 @@
 				9BECE1C21A9CBBD100CE2FD5 /* TLFormFieldImage.h */,
 				9BECE1C31A9CBBD100CE2FD5 /* TLFormFieldImage.m */,
 				9BECE1D31A9F89E200CE2FD5 /* TLFormAllFields.h */,
+				9BE9B0EC1B02562E009DA0BD /* TLFormFieldDateTime.h */,
+				9BE9B0ED1B02562E009DA0BD /* TLFormFieldDateTime.m */,
+				9BE9B0EF1B03A81B009DA0BD /* TLFormFieldNumeric.h */,
+				9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */,
 			);
 			path = Fields;
 			sourceTree = "<group>";
@@ -229,10 +252,13 @@
 			files = (
 				9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */,
 				9BECE1D21A9F899500CE2FD5 /* TLFormField+UIAppearance.m in Sources */,
+				9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */,
 				9BECE18B1A9B5B4D00CE2FD5 /* AppDelegate.m in Sources */,
 				9BECE1B81A9CB6DD00CE2FD5 /* TLFormFieldList.m in Sources */,
 				9BECE1B01A9B5B9800CE2FD5 /* TLFormView.m in Sources */,
+				9BE9B0F51B03BD13009DA0BD /* NSNumber+NumberType.m in Sources */,
 				9BECE1C41A9CBBD100CE2FD5 /* TLFormFieldImage.m in Sources */,
+				9BE9B0EE1B02562E009DA0BD /* TLFormFieldDateTime.m in Sources */,
 				9BECE1BE1A9CBAEC00CE2FD5 /* TLFormFieldSingleLine.m in Sources */,
 				9BECE1881A9B5B4D00CE2FD5 /* main.m in Sources */,
 				9BECE1C11A9CBB8B00CE2FD5 /* TLFormFieldTitle.m in Sources */,

--- a/Example/TLFormView.xcodeproj/project.pbxproj
+++ b/Example/TLFormView.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */; };
 		9BE9B0F51B03BD13009DA0BD /* NSNumber+NumberType.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */; };
 		9BE9B0F81B03C24A009DA0BD /* TLFormFieldYesNo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */; };
+		9BE9B0FB1B03D257009DA0BD /* TLFormFieldSelect.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0FA1B03D257009DA0BD /* TLFormFieldSelect.m */; };
 		9BECE1881A9B5B4D00CE2FD5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE1871A9B5B4D00CE2FD5 /* main.m */; };
 		9BECE18B1A9B5B4D00CE2FD5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18A1A9B5B4D00CE2FD5 /* AppDelegate.m */; };
 		9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18D1A9B5B4D00CE2FD5 /* ViewController.m */; };
@@ -39,6 +40,8 @@
 		9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+NumberType.m"; sourceTree = "<group>"; };
 		9BE9B0F61B03C24A009DA0BD /* TLFormFieldYesNo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TLFormFieldYesNo.h; sourceTree = "<group>"; };
 		9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldYesNo.m; sourceTree = "<group>"; };
+		9BE9B0F91B03D257009DA0BD /* TLFormFieldSelect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TLFormFieldSelect.h; sourceTree = "<group>"; };
+		9BE9B0FA1B03D257009DA0BD /* TLFormFieldSelect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldSelect.m; sourceTree = "<group>"; };
 		9BECE1821A9B5B4D00CE2FD5 /* TLFormView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TLFormView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BECE1861A9B5B4D00CE2FD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BECE1871A9B5B4D00CE2FD5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -172,6 +175,8 @@
 				9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */,
 				9BE9B0F61B03C24A009DA0BD /* TLFormFieldYesNo.h */,
 				9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */,
+				9BE9B0F91B03D257009DA0BD /* TLFormFieldSelect.h */,
+				9BE9B0FA1B03D257009DA0BD /* TLFormFieldSelect.m */,
 			);
 			path = Fields;
 			sourceTree = "<group>";
@@ -256,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */,
+				9BE9B0FB1B03D257009DA0BD /* TLFormFieldSelect.m in Sources */,
 				9BECE1D21A9F899500CE2FD5 /* TLFormField+UIAppearance.m in Sources */,
 				9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */,
 				9BE9B0F81B03C24A009DA0BD /* TLFormFieldYesNo.m in Sources */,

--- a/Example/TLFormView.xcodeproj/project.pbxproj
+++ b/Example/TLFormView.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		9BE9B0EE1B02562E009DA0BD /* TLFormFieldDateTime.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0ED1B02562E009DA0BD /* TLFormFieldDateTime.m */; };
 		9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */; };
 		9BE9B0F51B03BD13009DA0BD /* NSNumber+NumberType.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */; };
+		9BE9B0F81B03C24A009DA0BD /* TLFormFieldYesNo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */; };
 		9BECE1881A9B5B4D00CE2FD5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE1871A9B5B4D00CE2FD5 /* main.m */; };
 		9BECE18B1A9B5B4D00CE2FD5 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18A1A9B5B4D00CE2FD5 /* AppDelegate.m */; };
 		9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BECE18D1A9B5B4D00CE2FD5 /* ViewController.m */; };
@@ -36,6 +37,8 @@
 		9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldNumeric.m; sourceTree = "<group>"; };
 		9BE9B0F31B03BD13009DA0BD /* NSNumber+NumberType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+NumberType.h"; sourceTree = "<group>"; };
 		9BE9B0F41B03BD13009DA0BD /* NSNumber+NumberType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+NumberType.m"; sourceTree = "<group>"; };
+		9BE9B0F61B03C24A009DA0BD /* TLFormFieldYesNo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TLFormFieldYesNo.h; sourceTree = "<group>"; };
+		9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TLFormFieldYesNo.m; sourceTree = "<group>"; };
 		9BECE1821A9B5B4D00CE2FD5 /* TLFormView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TLFormView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BECE1861A9B5B4D00CE2FD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BECE1871A9B5B4D00CE2FD5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -167,6 +170,8 @@
 				9BE9B0ED1B02562E009DA0BD /* TLFormFieldDateTime.m */,
 				9BE9B0EF1B03A81B009DA0BD /* TLFormFieldNumeric.h */,
 				9BE9B0F01B03A81B009DA0BD /* TLFormFieldNumeric.m */,
+				9BE9B0F61B03C24A009DA0BD /* TLFormFieldYesNo.h */,
+				9BE9B0F71B03C24A009DA0BD /* TLFormFieldYesNo.m */,
 			);
 			path = Fields;
 			sourceTree = "<group>";
@@ -253,6 +258,7 @@
 				9BECE18E1A9B5B4D00CE2FD5 /* ViewController.m in Sources */,
 				9BECE1D21A9F899500CE2FD5 /* TLFormField+UIAppearance.m in Sources */,
 				9BE9B0F11B03A81B009DA0BD /* TLFormFieldNumeric.m in Sources */,
+				9BE9B0F81B03C24A009DA0BD /* TLFormFieldYesNo.m in Sources */,
 				9BECE18B1A9B5B4D00CE2FD5 /* AppDelegate.m in Sources */,
 				9BECE1B81A9CB6DD00CE2FD5 /* TLFormFieldList.m in Sources */,
 				9BECE1B01A9B5B9800CE2FD5 /* TLFormView.m in Sources */,

--- a/Example/TLFormView/ViewController.m
+++ b/Example/TLFormView/ViewController.m
@@ -9,6 +9,7 @@
 #import "ViewController.h"
 #import "TLFormView.h"
 #import "TLFormModel.h"
+#import "TLFormFieldDateTime.h"
 #import <MobileCoreServices/UTCoreTypes.h>
 
 
@@ -20,10 +21,10 @@
 @property (nonatomic, strong) TLFormNumber *age;
 @property (nonatomic, strong) TLFormBoolean *is_active;
 @property (nonatomic, strong) TLFormEnumerated *hobbies;
+@property (nonatomic, strong) TLFormDateTime *birthday;
 @property (nonatomic, strong) TLFormSeparator *separator;
 @property (nonatomic, strong) TLFormLongText *_description;
 @property (nonatomic, strong) TLFormList *friends;
-@property (nonatomic, strong) TLFormDateTime *date;
 
 @end
 
@@ -40,6 +41,13 @@
     //The "hobbies" field will be visible only when the user "is active"
     else if ([fieldName isEqualToString:@"hobbies"])
         field.visibilityPredicate = [NSPredicate predicateWithFormat:@"$is_active.value == YES"];
+    
+    //Set the date field format
+    else if ([fieldName isEqualToString:@"birthday"]) {
+        TLFormFieldDateTime *birthdayField = (TLFormFieldDateTime *) field;
+        birthdayField.dateFormat = @"MMMM dd, yyyy";
+        birthdayField.pickerMode = UIDatePickerModeDate;
+    }
     
     //Set all the borders when we are running on iPad
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad)
@@ -89,7 +97,10 @@
              @"H:|-[_description]-|",
              
              @"V:[_description]-[friends]-|",
-             @"H:|-[friends]-|",
+             @"H:|-[friends]",
+             
+             @"V:[_description]-[birthday(>=44)]",
+             @"H:|-[friends(==birthday)]-[birthday(==friends)]-|"
         ];
     }
 }
@@ -139,8 +150,7 @@
     
     NSURL *url = [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/custom_covers/216x146/413557246971119139_1385652535.jpg"];
     user.avatar = TLFormImageValue(url);
-    
-    user.date = TLFormDateTimeValue([NSDate date]);
+    user.birthday = TLFormDateTimeValue([NSDate date]);
 }
 
 #pragma mark - Bar Buttons Actions

--- a/Example/TLFormView/ViewController.m
+++ b/Example/TLFormView/ViewController.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) TLFormSeparator *separator;
 @property (nonatomic, strong) TLFormLongText *_description;
 @property (nonatomic, strong) TLFormList *friends;
+@property (nonatomic, strong) TLFormDateTime *date;
 
 @end
 
@@ -138,6 +139,8 @@
     
     NSURL *url = [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/custom_covers/216x146/413557246971119139_1385652535.jpg"];
     user.avatar = TLFormImageValue(url);
+    
+    user.date = TLFormDateTimeValue([NSDate date]);
 }
 
 #pragma mark - Bar Buttons Actions

--- a/Pod/Classes/Extensions/NSNumber+NumberType.h
+++ b/Pod/Classes/Extensions/NSNumber+NumberType.h
@@ -1,0 +1,23 @@
+//
+//  NSNumber+NumberType.h
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+extern const short kTLNumberBooleanType;
+extern const short kTLNumberNanType;
+
+//This category is used for handling the mapping between NSNumber types (numberWithBool:, numberWithFloat:, etc) and his string values. Ex: you give a "numberWithBool" as value
+//then the value is show as "Yes"/"No" and when the value is read you get a "numberWithBool" back. The same works for any type of number thanks to this category.
+@interface NSNumber (NumberType)
+
+- (CFNumberType)numberType;
++ (instancetype)numberOfType:(CFNumberType)type withValue:(id)value;
+
+@end
+

--- a/Pod/Classes/Extensions/NSNumber+NumberType.m
+++ b/Pod/Classes/Extensions/NSNumber+NumberType.m
@@ -1,0 +1,88 @@
+//
+//  NSNumber+NumberType.m
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "NSNumber+NumberType.h"
+
+
+//Add two specil values that will live side by side to the CFNumberType enum values
+const short kTLNumberBooleanType    = -1;
+const short kTLNumberNanType        = -2;
+
+@implementation NSNumber (NumberType)
+
+- (CFNumberType)numberType {
+    //Get if a number is NSNumber-bool value (see: http://stackoverflow.com/questions/2518761/get-type-of-nsnumber )
+    if (self == (id) kCFBooleanFalse || self == (id) kCFBooleanTrue)
+        return kTLNumberBooleanType;
+    else
+        return CFNumberGetType((CFNumberRef)self);
+}
+
+//Given a type and a value return the corresponding NSNumber. This is like use NSNumberFormatter but much better.
++ (instancetype)numberOfType:(CFNumberType)type withValue:(id)value {
+    
+    const void *numberValue = NULL;
+    
+    switch (type) {
+        case kCFNumberCharType:
+        case kCFNumberSInt8Type: {
+            char tmp = [value charValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberShortType:
+        case kCFNumberSInt16Type: {
+            short tmp = [value shortValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberIntType:
+        case kCFNumberSInt32Type: {
+            int tmp = [value intValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberLongType: {
+            long tmp = [value longValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberLongLongType:
+        case kCFNumberSInt64Type: {
+            long long tmp = [value longLongValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberCGFloatType:
+        case kCFNumberFloatType:
+        case kCFNumberFloat32Type: {
+            float tmp = [value floatValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberDoubleType:
+        case kCFNumberFloat64Type: {
+            double tmp = [value doubleValue];
+            numberValue = &tmp;
+            break;
+        }
+        case kCFNumberNSIntegerType: {
+            NSInteger tmp = [value integerValue];
+            numberValue = &tmp;
+            break;
+        }
+        default:
+            numberValue = NULL;
+            break;
+    }
+    
+    return CFBridgingRelease(CFNumberCreate(kCFAllocatorDefault, type, numberValue));
+}
+
+@end
+

--- a/Pod/Classes/Fields/TLFormAllFields.h
+++ b/Pod/Classes/Fields/TLFormAllFields.h
@@ -10,6 +10,7 @@
 #import "TLFormFieldMultiLine.h"
 #import "TLFormFieldSingleLine.h"
 #import "TLFormFieldNumeric.h"
+#import "TLFormFieldYesNo.h"
 #import "TLFormFieldTitle.h"
 #import "TLFormFieldImage.h"
 #import "TLFormFieldDateTime.h"

--- a/Pod/Classes/Fields/TLFormAllFields.h
+++ b/Pod/Classes/Fields/TLFormAllFields.h
@@ -11,6 +11,7 @@
 #import "TLFormFieldSingleLine.h"
 #import "TLFormFieldNumeric.h"
 #import "TLFormFieldYesNo.h"
+#import "TLFormFieldSelect.h"
 #import "TLFormFieldTitle.h"
 #import "TLFormFieldImage.h"
 #import "TLFormFieldDateTime.h"

--- a/Pod/Classes/Fields/TLFormAllFields.h
+++ b/Pod/Classes/Fields/TLFormAllFields.h
@@ -9,5 +9,7 @@
 #import "TLFormFieldList.h"
 #import "TLFormFieldMultiLine.h"
 #import "TLFormFieldSingleLine.h"
+#import "TLFormFieldNumeric.h"
 #import "TLFormFieldTitle.h"
 #import "TLFormFieldImage.h"
+#import "TLFormFieldDateTime.h"

--- a/Pod/Classes/Fields/TLFormField+Protected.h
+++ b/Pod/Classes/Fields/TLFormField+Protected.h
@@ -33,11 +33,9 @@ extern int const TLFormFieldValueLabelTag;
 @property (nonatomic, weak) id <TLFormFieldDelegate> formDelegate;
 @property (nonatomic, readonly) NSDictionary *defaultMetrics;
 @property (nonatomic, strong) NSString *title;
-
+@property (nonatomic, strong, setter = setValue: , getter = getValue) id fieldValue;
 
 - (void)setupField:(BOOL)editing;
-- (void)setValue:(id)fieldValue;
-- (id)getValue;
 - (UIView *)titleView;
 
 @end

--- a/Pod/Classes/Fields/TLFormField.h
+++ b/Pod/Classes/Fields/TLFormField.h
@@ -13,7 +13,7 @@ typedef enum {
     TLFormFieldBorderNone   = 0,
     TLFormFieldBorderTop    = 1 << 0,
     TLFormFieldBorderRight  = 1 << 1,
-    TLFormFieldBorderBottom  = 1 << 2,
+    TLFormFieldBorderBottom = 1 << 2,
     TLFormFieldBorderLeft   = 1 << 3,
     TLFormFieldBorderAll    = 255
 } TLFormFieldBorder;

--- a/Pod/Classes/Fields/TLFormField.m
+++ b/Pod/Classes/Fields/TLFormField.m
@@ -80,6 +80,7 @@
 //The base class for the form fields
 
 @implementation TLFormField {
+    UIView *_titleView;
     NSLayoutConstraint *hiddenConstraint;
     UIPopoverController *popover;
 }
@@ -198,6 +199,9 @@
 
 - (UIView *)titleView {
     
+    if (_titleView)
+        return _titleView;
+    
     UILabel *title = [[UILabel alloc] init];
     title.numberOfLines = 2;
     title.lineBreakMode = NSLineBreakByWordWrapping;
@@ -230,9 +234,11 @@
                                                                                options:NSLayoutFormatAlignAllCenterX
                                                                                metrics:nil
                                                                                  views:views]];
-        return titleContainer;
+        _titleView = titleContainer;
     } else
-        return title;
+        _titleView = title;
+    
+    return _titleView;
 }
 
 - (void)showHelpAction:(UIButton *)sender {

--- a/Pod/Classes/Fields/TLFormFieldDateTime.h
+++ b/Pod/Classes/Fields/TLFormFieldDateTime.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2015 Bruno Berisso. All rights reserved.
 //
 
-#import "TLFormField.h"
+#import "TLFormFieldSingleLine.h"
 
-@interface TLFormFieldDateTime : TLFormField
+@interface TLFormFieldDateTime : TLFormFieldSingleLine
 
 @end

--- a/Pod/Classes/Fields/TLFormFieldDateTime.h
+++ b/Pod/Classes/Fields/TLFormFieldDateTime.h
@@ -10,4 +10,7 @@
 
 @interface TLFormFieldDateTime : TLFormFieldSingleLine
 
+@property (nonatomic, strong) NSString *dateFormat;
+@property (nonatomic, assign) UIDatePickerMode pickerMode;
+
 @end

--- a/Pod/Classes/Fields/TLFormFieldDateTime.h
+++ b/Pod/Classes/Fields/TLFormFieldDateTime.h
@@ -1,0 +1,13 @@
+//
+//  TLFormFieldDateTime.h
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/12/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormField.h"
+
+@interface TLFormFieldDateTime : TLFormField
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldDateTime.m
+++ b/Pod/Classes/Fields/TLFormFieldDateTime.m
@@ -1,0 +1,65 @@
+//
+//  TLFormFieldDateTime.m
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/12/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldDateTime.h"
+#import "TLFormField+Protected.h"
+
+
+
+@implementation TLFormFieldDateTime {
+    NSDateFormatter *_formatter;
+}
+
+- (NSDateFormatter *)formatter {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _formatter = [[NSDateFormatter alloc] init];
+        
+    });
+    return _formatter;
+}
+
+- (void)setupField:(BOOL)editing {
+    [super setupField:editing];
+    
+    NSDictionary *metrics = [self defaultMetrics];
+    UIView *titleView = [self titleView];
+    [self addSubview:titleView];
+    
+    if (editing) {
+        
+        UILabel *titleLabel = (UILabel *) [titleView viewWithTag:TLFormFieldTitleLabelTag];
+        titleLabel.textColor = [UIColor grayColor];
+        
+        UIDatePicker *picker = [[UIDatePicker alloc] init];
+        picker.datePickerMode = UIDatePickerModeDateAndTime;
+        picker.translatesAutoresizingMaskIntoConstraints = NO;
+        picker.date = [self getValue];
+        [self addSubview:picker];
+        
+        NSDictionary *views = NSDictionaryOfVariableBindings(picker, titleView);
+        
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-np-[titleView][picker]-np-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-bp-[titleView]-bp-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+    } else {
+        
+        UILabel *dateLabel = [[UILabel alloc] init];
+        dateLabel.translatesAutoresizingMaskIntoConstraints = NO;
+        dateLabel.text = [[self formatter] stringFromDate:[self getValue]];
+        
+        
+    }
+}
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldDateTime.m
+++ b/Pod/Classes/Fields/TLFormFieldDateTime.m
@@ -17,20 +17,29 @@
     UIDatePicker *picker;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        self.dateFormat = @"MMM dd, yyyy HH:mm";
+        self.pickerMode = UIDatePickerModeDateAndTime;
+    }
+    return self;
+}
+
 - (NSDateFormatter *)formatter {
     dispatch_once(&_onceTokenFormatter, ^{
         _formatter = [[NSDateFormatter alloc] init];
-        _formatter.dateStyle = NSDateFormatterMediumStyle;
+        _formatter.dateFormat = self.dateFormat;
     });
     return _formatter;
 }
 
 - (void)setupFieldForEditing {
     picker = [[UIDatePicker alloc] init];
-    picker.datePickerMode = UIDatePickerModeTime;
+    picker.datePickerMode = self.pickerMode;
     picker.translatesAutoresizingMaskIntoConstraints = NO;
     [picker addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
     [self addSubview:picker];
+    self.clipsToBounds = YES;
     
     UIView *titleView = [self titleView];
     NSDictionary *views = NSDictionaryOfVariableBindings(picker, titleView);
@@ -40,6 +49,10 @@
                                                                  metrics:self.defaultMetrics
                                                                    views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-bp-[titleView]-bp-|"
+                                                                 options:0
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-np-[picker]-np-|"
                                                                  options:0
                                                                  metrics:self.defaultMetrics
                                                                    views:views]];

--- a/Pod/Classes/Fields/TLFormFieldNumeric.h
+++ b/Pod/Classes/Fields/TLFormFieldNumeric.h
@@ -1,0 +1,13 @@
+//
+//  TLFormFieldNumeric.h
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldSingleLine.h"
+
+@interface TLFormFieldNumeric : TLFormFieldSingleLine
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldNumeric.m
+++ b/Pod/Classes/Fields/TLFormFieldNumeric.m
@@ -15,11 +15,9 @@
     CFNumberType numberType;
 }
 
-- (void)setupField:(BOOL)editing {
-    [super setupField:editing];
-    
-    if (editing)
-        self.textField.keyboardType = UIKeyboardTypeNumberPad;
+- (void)setupFieldForEditing {
+    [super setupFieldForEditing];
+    self.textField.keyboardType = UIKeyboardTypeNumberPad;
 }
 
 //Get and Set value

--- a/Pod/Classes/Fields/TLFormFieldNumeric.m
+++ b/Pod/Classes/Fields/TLFormFieldNumeric.m
@@ -30,13 +30,24 @@
     if ([fieldValue isKindOfClass:[NSNumber class]]) {
         NSNumber *value = (NSNumber *) fieldValue;
         numberType = [value numberType];
-        self.textField.text = [value stringValue];
+        NSString *stringValue = [value stringValue];
+        
+        if (self.textField)
+            self.textField.text = stringValue;
+        else
+            self.valueViewText = stringValue;
     } else
         [NSException raise:@"Invalid field value" format:@"TLFormFieldNumeric only accept fields of type NSNumber. Suplied value: %@", fieldValue];
 }
 
 - (id)getValue {
-    NSString *stringValue = self.textField.text;
+    NSString *stringValue;
+    
+    if (self.textField)
+        stringValue = self.textField.text;
+    else
+        stringValue = self.valueViewText;
+        
     return [NSNumber numberOfType:numberType withValue:stringValue];
 }
 

--- a/Pod/Classes/Fields/TLFormFieldNumeric.m
+++ b/Pod/Classes/Fields/TLFormFieldNumeric.m
@@ -1,0 +1,68 @@
+//
+//  TLFormFieldNumeric.m
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldNumeric.h"
+#import "TLFormField+Protected.h"
+#import "NSNumber+NumberType.h"
+
+
+@implementation TLFormFieldNumeric{
+    CFNumberType numberType;
+}
+
+- (void)setupField:(BOOL)editing {
+    [super setupField:editing];
+    
+    if (editing)
+        self.textField.keyboardType = UIKeyboardTypeNumberPad;
+}
+
+//Get and Set value
+
+- (void)setValue:(id)fieldValue {
+    
+    if (!fieldValue)
+        return;
+    
+    if ([fieldValue isKindOfClass:[NSNumber class]]) {
+        NSNumber *value = (NSNumber *) fieldValue;
+        numberType = [value numberType];
+        self.textField.text = [value stringValue];
+    } else
+        [NSException raise:@"Invalid field value" format:@"TLFormFieldNumeric only accept fields of type NSNumber. Suplied value: %@", fieldValue];
+}
+
+- (id)getValue {
+    NSString *stringValue = self.textField.text;
+    return [NSNumber numberOfType:numberType withValue:stringValue];
+}
+
+//UITextFieldDelegate
+
+- (BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
+    [self.formDelegate didSelectField:self];
+    return YES;
+}
+
+- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+    
+    id newValue = nil;
+    
+    if (string.length > 0)
+        newValue = [textField.text stringByAppendingString:string];
+    else
+        newValue = [textField.text substringToIndex:textField.text.length - 1];
+    
+    //Translate the value to an NSNumber in the same domain as the one given to the fild as initial value
+    newValue = [NSNumber numberOfType:numberType withValue:newValue];
+    [self.formDelegate didChangeValueForField:self newValue:newValue];
+    
+    return YES;
+}
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldSelect.h
+++ b/Pod/Classes/Fields/TLFormFieldSelect.h
@@ -1,0 +1,16 @@
+//
+//  TLFormFieldSelect.h
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldSingleLine.h"
+
+@interface TLFormFieldSelect : TLFormFieldSingleLine
+
+//The list of values to show in the segmented control
+@property (nonatomic, strong) NSArray *choicesValues;
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldSelect.m
+++ b/Pod/Classes/Fields/TLFormFieldSelect.m
@@ -15,35 +15,32 @@
     UISegmentedControl *segmented;
 }
 
-- (void)setupField:(BOOL)editing {
-    [super setupField:editing];
+- (void)setupFieldForEditing {
     
-    if (editing) {
-        segmented = [[UISegmentedControl alloc] init];
-        segmented.tag = TLFormFieldValueLabelTag;
-        segmented.translatesAutoresizingMaskIntoConstraints = NO;
-        [segmented addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
-        
-        for (NSString *choice in self.choicesValues)
-            [segmented insertSegmentWithTitle:choice atIndex:[self.choicesValues indexOfObject:choice] animated:NO];
-        
-        [self addSubview:segmented];
-        
-        UIView *titleView = [self titleView];
-        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, segmented);
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-[segmented]-np-|"
-                                                                     options:NSLayoutFormatAlignAllCenterX
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-|"
-                                                                     options:NSLayoutFormatAlignAllCenterY
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[segmented]-bp-|"
-                                                                     options:NSLayoutFormatAlignAllCenterY
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
-    }
+    segmented = [[UISegmentedControl alloc] init];
+    segmented.tag = TLFormFieldValueLabelTag;
+    segmented.translatesAutoresizingMaskIntoConstraints = NO;
+    [segmented addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
+    
+    for (NSString *choice in self.choicesValues)
+        [segmented insertSegmentWithTitle:choice atIndex:[self.choicesValues indexOfObject:choice] animated:NO];
+    
+    [self addSubview:segmented];
+    
+    UIView *titleView = [self titleView];
+    NSDictionary *views = NSDictionaryOfVariableBindings(titleView, segmented);
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-[segmented]-np-|"
+                                                                 options:NSLayoutFormatAlignAllCenterX
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterY
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[segmented]-bp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterY
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
 }
 
 //Get and Set value

--- a/Pod/Classes/Fields/TLFormFieldSelect.m
+++ b/Pod/Classes/Fields/TLFormFieldSelect.m
@@ -61,7 +61,7 @@
                 }
             }
         } else
-            self.textField.text = stringValue;
+            self.valueViewText = stringValue;
         
     } else
         [NSException raise:@"Invalid field value" format:@"TLFormFieldSelect only accept fields of type NSString. Suplied value: %@", fieldValue];
@@ -71,7 +71,7 @@
     if (segmented)
         return [segmented titleForSegmentAtIndex:segmented.selectedSegmentIndex];
     else
-        return self.textField.text;
+        return self.valueViewText;
 }
 
 //UISegmented value change

--- a/Pod/Classes/Fields/TLFormFieldSelect.m
+++ b/Pod/Classes/Fields/TLFormFieldSelect.m
@@ -1,0 +1,86 @@
+//
+//  TLFormFieldSelect.m
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldSelect.h"
+#import "TLFormField+Protected.h"
+
+
+
+@implementation TLFormFieldSelect {
+    UISegmentedControl *segmented;
+}
+
+- (void)setupField:(BOOL)editing {
+    [super setupField:editing];
+    
+    if (editing) {
+        segmented = [[UISegmentedControl alloc] init];
+        segmented.tag = TLFormFieldValueLabelTag;
+        segmented.translatesAutoresizingMaskIntoConstraints = NO;
+        [segmented addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
+        
+        for (NSString *choice in self.choicesValues)
+            [segmented insertSegmentWithTitle:choice atIndex:[self.choicesValues indexOfObject:choice] animated:NO];
+        
+        [self addSubview:segmented];
+        
+        UIView *titleView = [self titleView];
+        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, segmented);
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-[segmented]-np-|"
+                                                                     options:NSLayoutFormatAlignAllCenterX
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-|"
+                                                                     options:NSLayoutFormatAlignAllCenterY
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[segmented]-bp-|"
+                                                                     options:NSLayoutFormatAlignAllCenterY
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
+    }
+}
+
+//Get and Set value
+
+- (void)setValue:(id)fieldValue {
+    
+    if (!fieldValue)
+        return;
+    
+    if ([fieldValue isKindOfClass:[NSString class]]) {
+        NSString *stringValue = (NSString *) fieldValue;
+        
+        if (segmented) {
+            for (int i = 0; i < [segmented numberOfSegments]; i++) {
+                if ([stringValue isEqualToString:[segmented titleForSegmentAtIndex:i]]) {
+                    segmented.selectedSegmentIndex = i;
+                    break;
+                }
+            }
+        } else
+            self.textField.text = stringValue;
+        
+    } else
+        [NSException raise:@"Invalid field value" format:@"TLFormFieldSelect only accept fields of type NSString. Suplied value: %@", fieldValue];
+}
+
+- (id)getValue {
+    if (segmented)
+        return [segmented titleForSegmentAtIndex:segmented.selectedSegmentIndex];
+    else
+        return self.textField.text;
+}
+
+//UISegmented value change
+
+- (void)controlValueChange {
+    [self.formDelegate didChangeValueForField:self newValue:[self getValue]];
+}
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.h
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.h
@@ -36,3 +36,11 @@ typedef enum : NSUInteger {
 @property (nonatomic, strong) NSArray *choicesValues;
 
 @end
+
+
+
+@interface TLFormFieldSingleLine (Protected)
+
+@property (nonatomic, readonly) UITextField *textField;
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.h
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.h
@@ -17,5 +17,6 @@
 @interface TLFormFieldSingleLine (Protected)
 
 @property (nonatomic, readonly) UITextField *textField;
+- (void)setupFieldForEditing;
 
 @end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.h
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.h
@@ -15,10 +15,6 @@
 typedef enum : NSUInteger {
     //The edition is done using the UITextField / UITextView class with and reported using the delegate
     TLFormFieldInputTypeDefault,
-    //The keyboard is set to 'number pad' and the layout change to "title - value" with the text field for the value with a maximum of 50 pixels
-    TLFormFieldInputTypeNumeric,
-    //Instead of a UIText* control use a UISwitch
-    TLFormFieldInputTypeInlineYesNo,
     //Instead of a UIText* control use a UISegmented control (This needs to be fixed to ask the data source for the options to show)
     TLFormFieldInputTypeInlineSelect,
     //This mark the field as disable and notify any tap using the form delegate. The controller should take care of the behavior

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.h
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.h
@@ -16,7 +16,9 @@
 
 @interface TLFormFieldSingleLine (Protected)
 
+@property (nonatomic, assign) NSString *valueViewText;
 @property (nonatomic, readonly) UITextField *textField;
+
 - (void)setupFieldForEditing;
 
 @end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.h
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.h
@@ -9,30 +9,9 @@
 #import "TLFormField.h"
 
 
-
-//The TLFormFieldType define how a fild will be showed. The TLFormFieldInputType define how a fild will behave when the form is in edit mode
-
-typedef enum : NSUInteger {
-    //The edition is done using the UITextField / UITextView class with and reported using the delegate
-    TLFormFieldInputTypeDefault,
-    //Instead of a UIText* control use a UISegmented control (This needs to be fixed to ask the data source for the options to show)
-    TLFormFieldInputTypeInlineSelect,
-    //This mark the field as disable and notify any tap using the form delegate. The controller should take care of the behavior
-    TLFormFieldInputTypeCustom
-} TLFormFieldInputType;
-
-
-
 @interface TLFormFieldSingleLine : TLFormField
 
-//How the field ascept and show values
-@property (nonatomic, assign) TLFormFieldInputType inputType;
-
-//The list of values to show in the segmented controll created for the LFormFieldInputTypeInlineSelect input type
-@property (nonatomic, strong) NSArray *choicesValues;
-
 @end
-
 
 
 @interface TLFormFieldSingleLine (Protected)

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.m
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.m
@@ -26,25 +26,8 @@
         
         UILabel *titleLabel = (UILabel *) [titleView viewWithTag:TLFormFieldTitleLabelTag];
         titleLabel.textColor = [UIColor grayColor];
+        [self setupFieldForEditing];
         
-        UITextField *textField = [[UITextField alloc] init];
-        textField.tag = TLFormFieldValueLabelTag;
-        textField.textAlignment = NSTextAlignmentRight;
-        textField.translatesAutoresizingMaskIntoConstraints = NO;
-        textField.borderStyle = UITextBorderStyleNone;
-        textField.delegate = self;
-        [self addSubview:textField];
-        
-        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
-        
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
-                                                                     options:NSLayoutFormatAlignAllCenterX
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
-                                                                     options:NSLayoutFormatAlignAllCenterY
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
     } else {
         
         UILabel *valueLabel = [[UILabel alloc] init];
@@ -78,6 +61,29 @@
     [self setValue:self.defautValue];
 }
 
+- (void)setupFieldForEditing {
+    
+    UITextField *textField = [[UITextField alloc] init];
+    textField.tag = TLFormFieldValueLabelTag;
+    textField.textAlignment = NSTextAlignmentRight;
+    textField.translatesAutoresizingMaskIntoConstraints = NO;
+    textField.borderStyle = UITextBorderStyleNone;
+    textField.delegate = self;
+    [self addSubview:textField];
+    
+    UIView *titleView = [self titleView];
+    NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterX
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterY
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+}
+
 - (CGSize)intrinsicContentSize {
     CGFloat width = 0.0, height = 0.0;
     
@@ -108,17 +114,6 @@
     
     if ([valueView respondsToSelector:@selector(setText:)])
         [valueView performSelector:@selector(setText:) withObject:stringValue];
-    
-    else if ([valueView isKindOfClass:[UISegmentedControl class]]) {
-        UISegmentedControl *segmented = (UISegmentedControl *)valueView;
-        
-        for (int i = 0; i < [segmented numberOfSegments]; i++) {
-            if ([stringValue isEqualToString:[segmented titleForSegmentAtIndex:i]]) {
-                segmented.selectedSegmentIndex = i;
-                break;
-            }
-        }
-    }
 }
 
 - (id)getValue {
@@ -128,12 +123,6 @@
         NSString *stringValue = [valueView performSelector:@selector(text)];
         return stringValue;
     }
-    
-    else if ([valueView isKindOfClass:[UISegmentedControl class]]) {
-        UISegmentedControl *segmented = (UISegmentedControl *)valueView;
-        return [segmented titleForSegmentAtIndex:segmented.selectedSegmentIndex];
-    }
-    
     return nil;
 }
 
@@ -141,7 +130,7 @@
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField {
     [self.formDelegate didSelectField:self];
-    return self.inputType != TLFormFieldInputTypeCustom;
+    return YES;
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
@@ -156,12 +145,6 @@
     [self.formDelegate didChangeValueForField:self newValue:newValue];
     
     return YES;
-}
-
-//UISwitch and UISegmented value change
-
-- (void)controlValueChange {
-    [self.formDelegate didChangeValueForField:self newValue:[self getValue]];
 }
 
 @end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.m
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.m
@@ -27,63 +27,24 @@
         UILabel *titleLabel = (UILabel *) [titleView viewWithTag:TLFormFieldTitleLabelTag];
         titleLabel.textColor = [UIColor grayColor];
         
-        switch (self.inputType) {
-                
-            case TLFormFieldInputTypeCustom:
-            case TLFormFieldInputTypeDefault: {
-                
-                UITextField *textField = [[UITextField alloc] init];
-                textField.tag = TLFormFieldValueLabelTag;
-                textField.textAlignment = NSTextAlignmentRight;
-                textField.translatesAutoresizingMaskIntoConstraints = NO;
-                textField.borderStyle = UITextBorderStyleNone;
-                textField.delegate = self;
-                [self addSubview:textField];
-                
-                NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
-                
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
-                                                                             options:NSLayoutFormatAlignAllCenterX
-                                                                             metrics:self.defaultMetrics
-                                                                               views:views]];
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
-                                                                             options:NSLayoutFormatAlignAllCenterY
-                                                                             metrics:self.defaultMetrics
-                                                                               views:views]];
-                break;
-            }
-                
-            case TLFormFieldInputTypeInlineSelect: {
-                
-                UISegmentedControl *segmented = [[UISegmentedControl alloc] init];
-                segmented.tag = TLFormFieldValueLabelTag;
-                segmented.translatesAutoresizingMaskIntoConstraints = NO;
-                [segmented addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
-                
-                for (NSString *choice in self.choicesValues)
-                    [segmented insertSegmentWithTitle:choice atIndex:[self.choicesValues indexOfObject:choice] animated:NO];
-                
-                [self addSubview:segmented];
-                
-                NSDictionary *views = NSDictionaryOfVariableBindings(titleView, segmented);
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-[segmented]-np-|"
-                                                                             options:NSLayoutFormatAlignAllCenterX
-                                                                             metrics:self.defaultMetrics
-                                                                               views:views]];
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-|"
-                                                                             options:NSLayoutFormatAlignAllCenterY
-                                                                             metrics:self.defaultMetrics
-                                                                               views:views]];
-                [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[segmented]-bp-|"
-                                                                             options:NSLayoutFormatAlignAllCenterY
-                                                                             metrics:self.defaultMetrics
-                                                                               views:views]];
-                break;
-            }
-            default:
-                break;
-        }
+        UITextField *textField = [[UITextField alloc] init];
+        textField.tag = TLFormFieldValueLabelTag;
+        textField.textAlignment = NSTextAlignmentRight;
+        textField.translatesAutoresizingMaskIntoConstraints = NO;
+        textField.borderStyle = UITextBorderStyleNone;
+        textField.delegate = self;
+        [self addSubview:textField];
         
+        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
+        
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
+                                                                     options:NSLayoutFormatAlignAllCenterX
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
+                                                                     options:NSLayoutFormatAlignAllCenterY
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
     } else {
         
         UILabel *valueLabel = [[UILabel alloc] init];

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.m
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.m
@@ -8,97 +8,7 @@
 
 #import "TLFormFieldSingleLine.h"
 #import "TLFormField+Protected.h"
-
-
-//This category is used for handling the mapping between NSNumber types (numberWithBool:, numberWithFloat:, etc) and his string values. Ex: you give a "numberWithBool" as value
-//then the value is show as "Yes"/"No" and when the value is read you get a "numberWithBool" back. The same works for any type of number thanks to this category.
-@interface NSNumber (NumberType)
-
-- (CFNumberType)numberType;
-+ (instancetype)numberOfType:(CFNumberType)type withValue:(id)value;
-
-@end
-
-//Add two specil values that will live side by side to the CFNumberType enum values
-const short kTLNumberBooleanType    = -1;
-const short kTLNumberNanType        = -2;
-
-@implementation NSNumber (NumberType)
-
-- (CFNumberType)numberType {
-    //Get if a number is NSNumber-bool value (see: http://stackoverflow.com/questions/2518761/get-type-of-nsnumber )
-    if (self == (id) kCFBooleanFalse || self == (id) kCFBooleanTrue)
-        return kTLNumberBooleanType;
-    else
-        return CFNumberGetType((CFNumberRef)self);
-}
-
-//Given a type and a value return the corresponding NSNumber. This is like use NSNumberFormatter but much better.
-+ (instancetype)numberOfType:(CFNumberType)type withValue:(id)value {
-    
-    const void *numberValue = NULL;
-    
-    switch (type) {
-        case kCFNumberCharType:
-        case kCFNumberSInt8Type: {
-            char tmp = [value charValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberShortType:
-        case kCFNumberSInt16Type: {
-            short tmp = [value shortValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberIntType:
-        case kCFNumberSInt32Type: {
-            int tmp = [value intValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberLongType: {
-            long tmp = [value longValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberLongLongType:
-        case kCFNumberSInt64Type: {
-            long long tmp = [value longLongValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberCGFloatType:
-        case kCFNumberFloatType:
-        case kCFNumberFloat32Type: {
-            float tmp = [value floatValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberDoubleType:
-        case kCFNumberFloat64Type: {
-            double tmp = [value doubleValue];
-            numberValue = &tmp;
-            break;
-        }
-        case kCFNumberNSIntegerType: {
-            NSInteger tmp = [value integerValue];
-            numberValue = &tmp;
-            break;
-        }
-        default:
-            numberValue = NULL;
-            break;
-    }
-    
-    return CFBridgingRelease(CFNumberCreate(kCFAllocatorDefault, type, numberValue));
-}
-
-@end
-
-
-
-
+#import "NSNumber+NumberType.h"
 
 
 @interface TLFormFieldSingleLine () <UITextFieldDelegate>
@@ -208,9 +118,6 @@ const short kTLNumberNanType        = -2;
                                                                     attribute:NSLayoutAttributeCenterY
                                                                    multiplier:1.0 constant:0.0],
                 ]];
-                
-                
-                
                 
                 break;
             }
@@ -375,3 +282,11 @@ const short kTLNumberNanType        = -2;
 
 @end
 
+
+@implementation TLFormFieldSingleLine (Protected)
+
+- (UITextField *)textField {
+    return (UITextField *) [self viewWithTag:TLFormFieldValueLabelTag];
+}
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldSingleLine.m
+++ b/Pod/Classes/Fields/TLFormFieldSingleLine.m
@@ -14,7 +14,9 @@
 @end
 
 
-@implementation TLFormFieldSingleLine
+@implementation TLFormFieldSingleLine {
+    UITextField *textField;
+}
 
 - (void)setupField:(BOOL)editing {
     [super setupField:editing];
@@ -61,29 +63,6 @@
     [self setValue:self.defautValue];
 }
 
-- (void)setupFieldForEditing {
-    
-    UITextField *textField = [[UITextField alloc] init];
-    textField.tag = TLFormFieldValueLabelTag;
-    textField.textAlignment = NSTextAlignmentRight;
-    textField.translatesAutoresizingMaskIntoConstraints = NO;
-    textField.borderStyle = UITextBorderStyleNone;
-    textField.delegate = self;
-    [self addSubview:textField];
-    
-    UIView *titleView = [self titleView];
-    NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
-    
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
-                                                                 options:NSLayoutFormatAlignAllCenterX
-                                                                 metrics:self.defaultMetrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
-                                                                 options:NSLayoutFormatAlignAllCenterY
-                                                                 metrics:self.defaultMetrics
-                                                                   views:views]];
-}
-
 - (CGSize)intrinsicContentSize {
     CGFloat width = 0.0, height = 0.0;
     
@@ -109,21 +88,17 @@
     else
         stringValue = fieldValue;
     
-    
-    id valueView = [self viewWithTag:TLFormFieldValueLabelTag];
-    
-    if ([valueView respondsToSelector:@selector(setText:)])
-        [valueView performSelector:@selector(setText:) withObject:stringValue];
+    if (textField)
+        textField.text = stringValue;
+    else
+        self.valueViewText = stringValue;
 }
 
 - (id)getValue {
-    id valueView = [self viewWithTag:TLFormFieldValueLabelTag];
-    
-    if ([valueView respondsToSelector:@selector(text)]) {
-        NSString *stringValue = [valueView performSelector:@selector(text)];
-        return stringValue;
-    }
-    return nil;
+    if (textField)
+        return textField.text;
+    else
+        return self.valueViewText;
 }
 
 //UITextFieldDelegate
@@ -133,14 +108,14 @@
     return YES;
 }
 
-- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
+- (BOOL)textField:(UITextField *)_textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
     
     id newValue = nil;
     
     if (string.length > 0)
-        newValue = [textField.text stringByAppendingString:string];
+        newValue = [_textField.text stringByAppendingString:string];
     else
-        newValue = [textField.text substringToIndex:textField.text.length - 1];
+        newValue = [_textField.text substringToIndex:_textField.text.length - 1];
     
     [self.formDelegate didChangeValueForField:self newValue:newValue];
     
@@ -152,8 +127,38 @@
 
 @implementation TLFormFieldSingleLine (Protected)
 
+- (NSString *)valueViewText {
+    return [[self viewWithTag:TLFormFieldValueLabelTag] performSelector:@selector(text)];
+}
+
+- (void)setValueViewText:(NSString *)valueViewText {
+    [[self viewWithTag:TLFormFieldValueLabelTag] performSelector:@selector(setText:) withObject:valueViewText];
+}
+
 - (UITextField *)textField {
-    return (UITextField *) [self viewWithTag:TLFormFieldValueLabelTag];
+    return textField;
+}
+
+- (void)setupFieldForEditing {
+    
+    textField = [[UITextField alloc] init];
+    textField.textAlignment = NSTextAlignmentRight;
+    textField.translatesAutoresizingMaskIntoConstraints = NO;
+    textField.borderStyle = UITextBorderStyleNone;
+    textField.delegate = self;
+    [self addSubview:textField];
+    
+    UIView *titleView = [self titleView];
+    NSDictionary *views = NSDictionaryOfVariableBindings(titleView, textField);
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-sp-[titleView]-sp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterX
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-np-[textField]-bp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterY
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
 }
 
 @end

--- a/Pod/Classes/Fields/TLFormFieldYesNo.h
+++ b/Pod/Classes/Fields/TLFormFieldYesNo.h
@@ -1,0 +1,13 @@
+//
+//  TLFormFieldYesNo.h
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldSingleLine.h"
+
+@interface TLFormFieldYesNo : TLFormFieldSingleLine
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldYesNo.m
+++ b/Pod/Classes/Fields/TLFormFieldYesNo.m
@@ -14,38 +14,35 @@
     UISwitch *yesNoSelect;
 }
 
-- (void)setupField:(BOOL)editing {
-    [super setupField:editing];
+- (void)setupFieldForEditing {
     
-    if (editing) {
-        yesNoSelect = [[UISwitch alloc] init];
-        yesNoSelect.tag = TLFormFieldValueLabelTag;
-        yesNoSelect.translatesAutoresizingMaskIntoConstraints = NO;
-        [yesNoSelect addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
-        
-        [self addSubview:yesNoSelect];
-        
-        UIView *titleView = [self titleView];
-        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, yesNoSelect);
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-[yesNoSelect]-bp-|"
-                                                                     options:NSLayoutFormatAlignAllCenterY
-                                                                     metrics:self.defaultMetrics
-                                                                       views:views]];
-        
-        //The vertical constraints needs to be set with explicit contraints because the visual format language can't express this rules.
-        [self addConstraint:[NSLayoutConstraint constraintWithItem:yesNoSelect
-                                                         attribute:NSLayoutAttributeCenterY
-                                                         relatedBy:NSLayoutRelationEqual
-                                                            toItem:self
-                                                         attribute:NSLayoutAttributeCenterY
-                                                        multiplier:1.0 constant:0.0]];
-        [self addConstraint:[NSLayoutConstraint constraintWithItem:titleView
-                                                         attribute:NSLayoutAttributeCenterY
-                                                         relatedBy:NSLayoutRelationEqual
-                                                            toItem:self
-                                                         attribute:NSLayoutAttributeCenterY
-                                                        multiplier:1.0 constant:0.0]];
-    }
+    yesNoSelect = [[UISwitch alloc] init];
+    yesNoSelect.tag = TLFormFieldValueLabelTag;
+    yesNoSelect.translatesAutoresizingMaskIntoConstraints = NO;
+    [yesNoSelect addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
+    
+    [self addSubview:yesNoSelect];
+    
+    UIView *titleView = [self titleView];
+    NSDictionary *views = NSDictionaryOfVariableBindings(titleView, yesNoSelect);
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-[yesNoSelect]-bp-|"
+                                                                 options:NSLayoutFormatAlignAllCenterY
+                                                                 metrics:self.defaultMetrics
+                                                                   views:views]];
+    
+    //The vertical constraints needs to be set with explicit contraints because the visual format language can't express this rules.
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:yesNoSelect
+                                                     attribute:NSLayoutAttributeCenterY
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:self
+                                                     attribute:NSLayoutAttributeCenterY
+                                                    multiplier:1.0 constant:0.0]];
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:titleView
+                                                     attribute:NSLayoutAttributeCenterY
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:self
+                                                     attribute:NSLayoutAttributeCenterY
+                                                    multiplier:1.0 constant:0.0]];
 }
 
 //Get and Set value
@@ -73,6 +70,8 @@
     else
         return @([self.textField.text boolValue]);
 }
+
+//UISwitch value change
 
 - (void)controlValueChange {
     [self.formDelegate didChangeValueForField:self newValue:[self getValue]];

--- a/Pod/Classes/Fields/TLFormFieldYesNo.m
+++ b/Pod/Classes/Fields/TLFormFieldYesNo.m
@@ -1,0 +1,83 @@
+//
+//  TLFormFieldYesNo.m
+//  TLFormView
+//
+//  Created by Bruno Berisso on 5/13/15.
+//  Copyright (c) 2015 Bruno Berisso. All rights reserved.
+//
+
+#import "TLFormFieldYesNo.h"
+#import "TLFormField+Protected.h"
+
+
+@implementation TLFormFieldYesNo {
+    UISwitch *yesNoSelect;
+}
+
+- (void)setupField:(BOOL)editing {
+    [super setupField:editing];
+    
+    if (editing) {
+        yesNoSelect = [[UISwitch alloc] init];
+        yesNoSelect.tag = TLFormFieldValueLabelTag;
+        yesNoSelect.translatesAutoresizingMaskIntoConstraints = NO;
+        [yesNoSelect addTarget:self action:@selector(controlValueChange) forControlEvents:UIControlEventValueChanged];
+        
+        [self addSubview:yesNoSelect];
+        
+        UIView *titleView = [self titleView];
+        NSDictionary *views = NSDictionaryOfVariableBindings(titleView, yesNoSelect);
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-bp-[titleView]-bp-[yesNoSelect]-bp-|"
+                                                                     options:NSLayoutFormatAlignAllCenterY
+                                                                     metrics:self.defaultMetrics
+                                                                       views:views]];
+        
+        //The vertical constraints needs to be set with explicit contraints because the visual format language can't express this rules.
+        [self addConstraints:@[
+                               [NSLayoutConstraint constraintWithItem:yesNoSelect
+                                                            attribute:NSLayoutAttributeCenterY
+                                                            relatedBy:NSLayoutRelationEqual
+                                                               toItem:self
+                                                            attribute:NSLayoutAttributeCenterY
+                                                           multiplier:1.0 constant:0.0],
+                               [NSLayoutConstraint constraintWithItem:titleView
+                                                            attribute:NSLayoutAttributeCenterY
+                                                            relatedBy:NSLayoutRelationEqual
+                                                               toItem:self
+                                                            attribute:NSLayoutAttributeCenterY
+                                                           multiplier:1.0 constant:0.0],
+                               ]];
+    }
+}
+
+//Get and Set value
+
+- (void)setValue:(id)fieldValue {
+    
+    if (!fieldValue)
+        return;
+    
+    if ([fieldValue isKindOfClass:[NSNumber class]]) {
+        NSNumber *value = (NSNumber *) fieldValue;
+        
+        if (yesNoSelect)
+            yesNoSelect.on = [value boolValue];
+        else
+            self.textField.text = [value boolValue] ? @"Yes" : @"No";
+        
+    } else
+        [NSException raise:@"Invalid field value" format:@"TLFormFieldYesNo only accept fields of type NSNumber (boolean). Suplied value: %@", fieldValue];
+}
+
+- (id)getValue {
+    if (yesNoSelect)
+        return @(yesNoSelect.on);
+    else
+        return @([self.textField.text boolValue]);
+}
+
+- (void)controlValueChange {
+    [self.formDelegate didChangeValueForField:self newValue:[self getValue]];
+}
+
+@end

--- a/Pod/Classes/Fields/TLFormFieldYesNo.m
+++ b/Pod/Classes/Fields/TLFormFieldYesNo.m
@@ -33,20 +33,18 @@
                                                                        views:views]];
         
         //The vertical constraints needs to be set with explicit contraints because the visual format language can't express this rules.
-        [self addConstraints:@[
-                               [NSLayoutConstraint constraintWithItem:yesNoSelect
-                                                            attribute:NSLayoutAttributeCenterY
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:self
-                                                            attribute:NSLayoutAttributeCenterY
-                                                           multiplier:1.0 constant:0.0],
-                               [NSLayoutConstraint constraintWithItem:titleView
-                                                            attribute:NSLayoutAttributeCenterY
-                                                            relatedBy:NSLayoutRelationEqual
-                                                               toItem:self
-                                                            attribute:NSLayoutAttributeCenterY
-                                                           multiplier:1.0 constant:0.0],
-                               ]];
+        [self addConstraint:[NSLayoutConstraint constraintWithItem:yesNoSelect
+                                                         attribute:NSLayoutAttributeCenterY
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:self
+                                                         attribute:NSLayoutAttributeCenterY
+                                                        multiplier:1.0 constant:0.0]];
+        [self addConstraint:[NSLayoutConstraint constraintWithItem:titleView
+                                                         attribute:NSLayoutAttributeCenterY
+                                                         relatedBy:NSLayoutRelationEqual
+                                                            toItem:self
+                                                         attribute:NSLayoutAttributeCenterY
+                                                        multiplier:1.0 constant:0.0]];
     }
 }
 

--- a/Pod/Classes/Fields/TLFormFieldYesNo.m
+++ b/Pod/Classes/Fields/TLFormFieldYesNo.m
@@ -58,7 +58,7 @@
         if (yesNoSelect)
             yesNoSelect.on = [value boolValue];
         else
-            self.textField.text = [value boolValue] ? @"Yes" : @"No";
+            self.valueViewText = [value boolValue] ? @"Yes" : @"No";
         
     } else
         [NSException raise:@"Invalid field value" format:@"TLFormFieldYesNo only accept fields of type NSNumber (boolean). Suplied value: %@", fieldValue];
@@ -68,7 +68,7 @@
     if (yesNoSelect)
         return @(yesNoSelect.on);
     else
-        return @([self.textField.text boolValue]);
+        return @([self.valueViewText boolValue]);
 }
 
 //UISwitch value change

--- a/Pod/Classes/TLFormModel.h
+++ b/Pod/Classes/TLFormModel.h
@@ -44,6 +44,8 @@ TLFormList * TLFormListValue(NSArray *array);
 @interface TLFormImage : NSObject @end
 TLFormImage * TLFormImageValue (NSObject *urlOrImage);
 
+@interface TLFormDateTime : NSDate @end
+TLFormDateTime * TLFormDateTimeValue (NSDate *date);
 
 /**
  @abstract Model a form using an object.

--- a/Pod/Classes/TLFormModel.m
+++ b/Pod/Classes/TLFormModel.m
@@ -65,6 +65,10 @@ TLFormImage * TLFormImageValue (NSObject *urlOrImage) {
     }
 }
 
+@implementation TLFormDateTime : NSDate @end
+TLFormDateTime * TLFormDateTimeValue (NSDate *date) {
+    return (TLFormDateTime *) [date copy];
+}
 
 
 typedef enum {
@@ -77,7 +81,8 @@ typedef enum {
     TLFormValueTypeBoolean,
     TLFormValueTypeEnumerated,
     TLFormValueTypeList,
-    TLFormValueTypeImage
+    TLFormValueTypeImage,
+    TLFormValueTypeDateTime
 } TLFormValueType;
 
 
@@ -136,7 +141,8 @@ typedef enum {
                         @"TLFormBoolean",
                         @"TLFormEnumerated",
                         @"TLFormList",
-                        @"TLFormImage"] indexOfObject:stringType];
+                        @"TLFormImage",
+                        @"TLFormDateTime"] indexOfObject:stringType];
     
     if (idx != NSNotFound)
         return (TLFormValueType) idx + 1;
@@ -169,8 +175,7 @@ typedef enum {
             break;
             
         case TLFormValueTypeNumber:
-            _inputType = TLFormFieldInputTypeNumeric;
-            _fieldClass = [TLFormFieldSingleLine class];
+            _fieldClass = [TLFormFieldNumeric class];
             break;
         
         case TLFormValueTypeBoolean:
@@ -189,6 +194,10 @@ typedef enum {
         
         case TLFormValueTypeImage:
             _fieldClass = [TLFormFieldImage class];
+            break;
+        
+        case TLFormValueTypeDateTime:
+            _fieldClass = [TLFormFieldDateTime class];
             break;
             
         default:

--- a/Pod/Classes/TLFormModel.m
+++ b/Pod/Classes/TLFormModel.m
@@ -179,8 +179,7 @@ typedef enum {
             break;
         
         case TLFormValueTypeBoolean:
-            _inputType = TLFormFieldInputTypeInlineYesNo;
-            _fieldClass = [TLFormFieldSingleLine class];
+            _fieldClass = [TLFormFieldYesNo class];
             break;
         
         case TLFormValueTypeEnumerated:

--- a/Pod/Classes/TLFormModel.m
+++ b/Pod/Classes/TLFormModel.m
@@ -183,8 +183,7 @@ typedef enum {
             break;
         
         case TLFormValueTypeEnumerated:
-            _inputType = TLFormFieldInputTypeInlineSelect;
-            _fieldClass = [TLFormFieldSingleLine class];
+            _fieldClass = [TLFormFieldSelect class];
             break;
         
         case TLFormValueTypeList:
@@ -285,11 +284,9 @@ typedef enum {
     TLFormField *field = [fieldInfo.fieldClass formFieldWithName:fieldName title:fieldInfo.title andDefaultValue:value];
     
     //Set the properties specific for the single line field class
-    if ([fieldInfo.fieldClass isSubclassOfClass:[TLFormFieldSingleLine class]]) {
+    if ([fieldInfo.fieldClass isSubclassOfClass:[TLFormFieldSelect class]]) {
         
-        TLFormFieldSingleLine *singleLineField = (TLFormFieldSingleLine *) field;
-        
-        singleLineField.inputType = fieldInfo.inputType;
+        TLFormFieldSelect *singleLineField = (TLFormFieldSelect *) field;
         singleLineField.choicesValues = choices;
         
     } else if ([fieldInfo.fieldClass isSubclassOfClass:[TLFormFieldList class]]) {

--- a/Pod/Classes/TLFormModel.m
+++ b/Pod/Classes/TLFormModel.m
@@ -91,7 +91,6 @@ typedef enum {
 
 @property (nonatomic, strong) NSString *name;
 @property (nonatomic, readonly) Class fieldClass;
-@property (nonatomic, readonly) TLFormFieldInputType inputType;
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) TLFormValueType valueType;
 
@@ -153,8 +152,6 @@ typedef enum {
 - (void)setupFieldInfo {
     
     //Map the value types to field and input types to define de behaviour of each type of value
-    
-    _inputType = TLFormFieldInputTypeDefault;
     
     switch (self.valueType) {
             


### PR DESCRIPTION
Refactor ``TLFormFieldSingleLine`` to handle only the single line text input type. Now all the logic previously using the ``inputType`` property of this class is moved to a new class. The new classes are:
* TLFormFieldYesNo: use an ``UISwitch`` to edit a boolean value
* TLFormFieldSelect: use a ``UISegment`` to edit a value
* TLFormFieldNumeric: set the ``keyboardType`` of a ``UITextField`` to numeric and handle the conversion between ``NSString`` and ``NSNumber`` of a correct type.

Also as part of the refactor there is a new class extending ``TLFormFieldSingleLine`` for handling dates ``TLFormFieldDateTime``.